### PR TITLE
Update APIs.guru URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ You can replace the API_BASE_URL with the URL to your own installation if you ru
 
 ### Examples
 
-The tests import sample files from [APIs.guru - Wikipedia for Web APIs](https://github.com/APIs-guru/api-models), specifically through the [API endpoint](https://github.com/APIs-guru/api-models/blob/master/API.md).  
+The tests import sample files from [APIs.guru - Wikipedia for Web APIs](https://APIs.guru), specifically through the [API endpoint](https://github.com/APIs-guru/api-models/blob/master/API.md).

--- a/test/ardoq/swagger_test.clj
+++ b/test/ardoq/swagger_test.clj
@@ -83,7 +83,7 @@
              (count (:references swag)))))))
 
 (deftest import-swaggers
-  (doall (take 5 (for [[name swag] (:body (http/get "https://apis-guru.github.io/api-models/api/v1/list.json" {:as :json}))] 
+  (doall (take 5 (for [[name swag] (:body (http/get "https://api.apis.guru/v2/list.json" {:as :json}))] 
                    (let  [spec (->> swag 
                                     (:versions) 
                                     ((keyword (:preferred swag)))


### PR DESCRIPTION
We are migrating our URLs to `APIs.guru` domain, here is more details:
https://github.com/APIs-guru/api-models/issues/85