### PR TITLE
CircleCI: fix pushing images to Docker Hub

### DIFF
--- a/.circleci/deploy-docker.sh
+++ b/.circleci/deploy-docker.sh
@@ -10,7 +10,7 @@ then
 fi
 
 RESPONSE=$(curl --write-out %{http_code} --silent --output /dev/null -H "Authorization: Basic $DOCKER_AUTH" \
-                "https://index.docker.io/v1/repositories/$REPOSITORY/tags/$DOCKER_TAG")
+                "https://hub.docker.com/v1/repositories/$REPOSITORY/tags/$DOCKER_TAG")
 
 if [ $RESPONSE -eq 404 ]; then
     echo "Building docker container..."


### PR DESCRIPTION
HTTP/1.1 301 Moved Permanently
content-length: 0
location: https://hub.docker.com/v1/repositories/ardoq-api/tags/latest